### PR TITLE
Remove extra tags on genbank files for fluorescent proteins

### DIFF
--- a/Fluorescent Reporter Proteins/120957.gb
+++ b/Fluorescent Reporter Proteins/120957.gb
@@ -1,4 +1,4 @@
-LOCUS       mRFP1:_Addgene_C5m       681 bp ds-DNA     circular     06-AUG-2021
+LOCUS       mRFP1       681 bp ds-DNA     circular     06-AUG-2021
 DEFINITION  .
 KEYWORDS    "accession:addgene_120957_231025"                                  
 SOURCE      synthetic DNA construct                                            

--- a/Fluorescent Reporter Proteins/26495.gb
+++ b/Fluorescent Reporter Proteins/26495.gb
@@ -1,4 +1,4 @@
-LOCUS       GFPmut3:_Addgene         720 bp ds-DNA     linear       09-AUG-2021
+LOCUS       GFPmut3         720 bp ds-DNA     linear       09-AUG-2021
 DEFINITION  .
 FEATURES             Location/Qualifiers
      CDS             1..685

--- a/Fluorescent Reporter Proteins/54827.gb
+++ b/Fluorescent Reporter Proteins/54827.gb
@@ -1,4 +1,4 @@
-LOCUS       mKate2:_Addgene          699 bp ds-DNA     circular     09-AUG-2021
+LOCUS       mKate2          699 bp ds-DNA     circular     09-AUG-2021
 DEFINITION  .
 KEYWORDS    "accession:addgene_54827_271345"                                   
 SOURCE      synthetic DNA construct                                            

--- a/Fluorescent Reporter Proteins/ky021423.gb
+++ b/Fluorescent Reporter Proteins/ky021423.gb
@@ -1,4 +1,4 @@
-LOCUS       mScarlet:_KY021423.1     702 bp ds-DNA     linear       09-AUG-2021
+LOCUS       mScarlet     702 bp ds-DNA     linear       09-AUG-2021
 DEFINITION  .
 KEYWORDS    "accession:KY021423.1"                                             
 FEATURES             Location/Qualifiers


### PR DESCRIPTION
Four of the fluorescent proteins had "identity:source" tags on their genbank files that were causing them to not match their associated IDs in the Excel file. I propose to remove these extra tags. The alternative is to add the names to the Excel files, but I don't think that's necessary.
