### PR TITLE
Read the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,6 +24,6 @@ sphinx:
 #    - pdf
 
 # Optionally declare the Python requirements required to build your docs
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+# python:
+#   install:
+#   - requirements: docs/requirements.txt

--- a/distribution.gb
+++ b/distribution.gb
@@ -7480,10 +7480,10 @@ FEATURES             Location/Qualifiers
                      /label="BioBrick prefix"
      misc_feature    64..2133
                      /label="pSB1C3"
-     promoter        1..63
+     misc_feature    1..63
                      /label="pBetI"
 ORIGIN
-        1 agcgcgggtg agagggattc gttaccaatt gacaattgat tggacgttca atataatgct
+        1 agcgcgggtg agagggattc gttaccaata gacaattgat tggacgttca atataatgct
        61 agctactagt agcggccgct gcagtccggc aaaaaagggc aaggtgtcac caccctgccc
       121 tttttcttta aaaccgaaaa gattacttcg cgttatgcag gcttcctcgc tcactgactc
       181 gctgcgctcg gtcgttcggc tgcggcgagc ggtatcagct cactcaaagg cggtaatacg

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/code/building.rst
+++ b/docs/code/building.rst
@@ -1,0 +1,2 @@
+How to build the distribution locally for testing
+=================================================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'iGEM-distribution'
+copyright = '2022, To be added'
+author = 'To be added'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,9 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------
@@ -28,11 +28,18 @@ author = 'To be added'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.napoleon',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.coverage',
+    'autoapi.extension'
 ]
+
+# See https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html
+autoapi_dirs = ['../scripts/scriptutils']
+autoapi_options = ['members', 'undoc-members', 'show-inheritance',
+                   'show-module-summary', 'special-members']
+autoapi_python_class_content = 'both'
+autoapi_member_order = 'alphabetical'
+# If true, the current module name will be prepended to all description
+# unit titles (such as .. function::).
+add_module_names = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx-rtd-theme'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,10 @@ author = 'To be added'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.napoleon',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.coverage',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -44,7 +48,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx-rtd-theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/contributing/code.rst
+++ b/docs/contributing/code.rst
@@ -1,0 +1,2 @@
+Contributing code to the distribution
+=====================================

--- a/docs/contributing/commenting.rst
+++ b/docs/contributing/commenting.rst
@@ -1,0 +1,2 @@
+Commenting on issues/packages
+=============================

--- a/docs/contributing/dna.rst
+++ b/docs/contributing/dna.rst
@@ -1,0 +1,3 @@
+Contributing packages to the distribution
+=========================================
+

--- a/docs/contributing/documentation.rst
+++ b/docs/contributing/documentation.rst
@@ -1,0 +1,2 @@
+How the distribution documentation works
+========================================

--- a/docs/contributing/reviewing.rst
+++ b/docs/contributing/reviewing.rst
@@ -1,0 +1,2 @@
+Reviewing DNA packages
+======================

--- a/docs/contributing/using.rst
+++ b/docs/contributing/using.rst
@@ -1,0 +1,2 @@
+Using/ordering the distribution
+===============================

--- a/docs/getting_started/github.rst
+++ b/docs/getting_started/github.rst
@@ -1,0 +1,2 @@
+Getting started with Github
+===========================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+.. iGEM-distribution documentation master file, created by
+   sphinx-quickstart on Tue Jan 18 09:19:45 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to iGEM-distribution's documentation!
+=============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,11 +6,54 @@
 Welcome to iGEM-distribution's documentation!
 =============================================
 
+.. Hidden TOCs
+
 .. toctree::
+   :caption: Getting started
    :maxdepth: 2
-   :caption: Contents:
+   :hidden:
+
+   getting_started/github
+
+.. toctree::
+   :caption: Contributing
+   :maxdepth: 2
+   :hidden:
+
+   contributing/dna
+   contributing/reviewing
+   contributing/commenting
+   contributing/using
+   contributing/documentation
+   contributing/code 
+
+.. toctree::
+   :caption: Code/APIs
+   :maxdepth: 2
+   :hidden:
+
+   code/building
 
 
+Getting started
+---------------
+
+We know that this way of working may be unfamiliar to many of you, but we believe that it's the best way to make the development of the new distribution as open and collaborative as possible! Don't worry if you've never used github before:
+
+- :doc:`Guide to Github <getting_started/github>`
+
+
+Contributing
+------------
+
+There are 6 main ways to contribute to the iGEM distribution, and we appreciate help with any one!
+
+1. :doc:`Contributing DNA packages <contributing/dna>`
+2. :doc:`Reviewing DNA packages <contributing/dna>`
+3. :doc:`Commenting/feedback on packages and issues <contributing/commenting>`
+4. :doc:`Using the distribution <contributing/using>`
+5. :doc:`Improving documentation <contributing/documentation>`
+6. :doc:`Improving the codebase <contributing/code>`
 
 Indices and tables
 ==================

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 # these are fixed in accordance with rtd recommendations: https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#pinning-dependencies
 sphinx==4.4.0
 sphinx_rtd_theme==1.0.0
+sphinx-autoapi==1.8.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+# these are fixed in accordance with rtd recommendations: https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#pinning-dependencies
+sphinx==4.4.0
+sphinx_rtd_theme==1.0.0
+readthedocs-sphinx-search==0.1.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
 # these are fixed in accordance with rtd recommendations: https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#pinning-dependencies
 sphinx==4.4.0
 sphinx_rtd_theme==1.0.0
-readthedocs-sphinx-search==0.1.1

--- a/scripts/scriptutils/directories.py
+++ b/scripts/scriptutils/directories.py
@@ -41,7 +41,7 @@ def package_dirs() -> List[str]:
     List of package directory path names
     """
     root = git.Repo('.', search_parent_directories=True).working_tree_dir
-    exclusions = {'scripts'}
+    exclusions = {'scripts', 'docs'}
     return [d.path for d in os.scandir(root) if d.is_dir() and not (d.name in exclusions or d.name.startswith('.'))]
 
 


### PR DESCRIPTION
Addressing issue #155 I have added the bits needed in the repo to connect to a read-the-docs site. This is a minimal setup that we can build from in future.

- I added a .readthedocs.yaml configuration file in the root of the repository
- I added a docs directory and populated it with the sphinx defaults using sphinx-quickstart
- I added a few sphinx extensions and changed the theme to the read-the-docs theme
- I edited the `package_dirs` function to also exclude the docs folder from its list of package folders

**Note:** Although this passes the tests here, until we link it to the read-the-docs site we won't know if it builds there. So please don't merge this pull request until that has been done and we have verified that it works. @vinoo-igem I think you'd be the best person to set up an account there and link this repository to it ([This tutorial](https://docs.readthedocs.io/en/stable/tutorial/#sign-up-for-read-the-docs) starting from 'Sign up for read the docs'). Then you'll need to go to Admin>Advanced settings>Default branch and change that to read-the-docs. 