### PR TITLE
Make sure all docs source is one-line-per-sentence

### DIFF
--- a/CRISPR-Cas/views/package.nt
+++ b/CRISPR-Cas/views/package.nt
@@ -100,13 +100,60 @@
 <http://parts.igem.org/pSB1C3_sequence> <http://sbols.org/v3#hasNamespace> <http://parts.igem.org> .
 <http://parts.igem.org/pSB1C3_sequence> <http://sbols.org/v3#name> "pSB1C3" .
 <http://parts.igem.org/pSB1C3_sequence> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Sequence> .
-<http://parts.igem.org/pSB1C5> <http://sbols.org/v3#description> "pSB1C5" .
+<http://parts.igem.org/pSB1C5/annotation0/range> <http://sbols.org/v3#displayId> "range" .
+<http://parts.igem.org/pSB1C5/annotation0/range> <http://sbols.org/v3#end> "58" .
+<http://parts.igem.org/pSB1C5/annotation0/range> <http://sbols.org/v3#hasSequence> <http://parts.igem.org/pSB1C5_seq> .
+<http://parts.igem.org/pSB1C5/annotation0/range> <http://sbols.org/v3#orientation> <http://sbols.org/v3#inline> .
+<http://parts.igem.org/pSB1C5/annotation0/range> <http://sbols.org/v3#start> "1" .
+<http://parts.igem.org/pSB1C5/annotation0/range> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Range> .
+<http://parts.igem.org/pSB1C5/annotation0> <http://purl.org/dc/terms/title> "his operon terminator" .
+<http://parts.igem.org/pSB1C5/annotation0> <http://sbols.org/genBankConversion#label> "his operon terminator" .
+<http://parts.igem.org/pSB1C5/annotation0> <http://sbols.org/v3#displayId> "annotation0" .
+<http://parts.igem.org/pSB1C5/annotation0> <http://sbols.org/v3#hasLocation> <http://parts.igem.org/pSB1C5/annotation0/range> .
+<http://parts.igem.org/pSB1C5/annotation0> <http://sbols.org/v3#name> "his operon terminator" .
+<http://parts.igem.org/pSB1C5/annotation0> <http://sbols.org/v3#role> <http://identifiers.org/so/SO:0000313> .
+<http://parts.igem.org/pSB1C5/annotation0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#SequenceFeature> .
+<http://parts.igem.org/pSB1C5/annotation1/range> <http://sbols.org/v3#displayId> "range" .
+<http://parts.igem.org/pSB1C5/annotation1/range> <http://sbols.org/v3#end> "841" .
+<http://parts.igem.org/pSB1C5/annotation1/range> <http://sbols.org/v3#hasSequence> <http://parts.igem.org/pSB1C5_seq> .
+<http://parts.igem.org/pSB1C5/annotation1/range> <http://sbols.org/v3#orientation> <http://sbols.org/v3#inline> .
+<http://parts.igem.org/pSB1C5/annotation1/range> <http://sbols.org/v3#start> "253" .
+<http://parts.igem.org/pSB1C5/annotation1/range> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Range> .
+<http://parts.igem.org/pSB1C5/annotation1> <http://purl.org/dc/terms/title> "pMB1 replication origin" .
+<http://parts.igem.org/pSB1C5/annotation1> <http://sbols.org/genBankConversion#label> "pMB1 replication origin" .
+<http://parts.igem.org/pSB1C5/annotation1> <http://sbols.org/v3#displayId> "annotation1" .
+<http://parts.igem.org/pSB1C5/annotation1> <http://sbols.org/v3#hasLocation> <http://parts.igem.org/pSB1C5/annotation1/range> .
+<http://parts.igem.org/pSB1C5/annotation1> <http://sbols.org/v3#name> "pMB1 replication origin" .
+<http://parts.igem.org/pSB1C5/annotation1> <http://sbols.org/v3#role> <http://identifiers.org/so/SO:0001411> .
+<http://parts.igem.org/pSB1C5/annotation1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#SequenceFeature> .
+<http://parts.igem.org/pSB1C5/annotation2/range> <http://sbols.org/v3#displayId> "range" .
+<http://parts.igem.org/pSB1C5/annotation2/range> <http://sbols.org/v3#end> "1798" .
+<http://parts.igem.org/pSB1C5/annotation2/range> <http://sbols.org/v3#hasSequence> <http://parts.igem.org/pSB1C5_seq> .
+<http://parts.igem.org/pSB1C5/annotation2/range> <http://sbols.org/v3#orientation> <http://sbols.org/v3#reverseComplement> .
+<http://parts.igem.org/pSB1C5/annotation2/range> <http://sbols.org/v3#start> "1139" .
+<http://parts.igem.org/pSB1C5/annotation2/range> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Range> .
+<http://parts.igem.org/pSB1C5/annotation2> <http://purl.org/dc/terms/title> "chloramphenicol resistance marker" .
+<http://parts.igem.org/pSB1C5/annotation2> <http://sbols.org/genBankConversion#label> "chloramphenicol resistance marker" .
+<http://parts.igem.org/pSB1C5/annotation2> <http://sbols.org/v3#displayId> "annotation2" .
+<http://parts.igem.org/pSB1C5/annotation2> <http://sbols.org/v3#hasLocation> <http://parts.igem.org/pSB1C5/annotation2/range> .
+<http://parts.igem.org/pSB1C5/annotation2> <http://sbols.org/v3#name> "chloramphenicol resistance marker" .
+<http://parts.igem.org/pSB1C5/annotation2> <http://sbols.org/v3#role> <http://identifiers.org/so/SO:0001411> .
+<http://parts.igem.org/pSB1C5/annotation2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#SequenceFeature> .
+<http://parts.igem.org/pSB1C5> <http://sbols.org/v3#description> "." .
 <http://parts.igem.org/pSB1C5> <http://sbols.org/v3#displayId> "pSB1C5" .
+<http://parts.igem.org/pSB1C5> <http://sbols.org/v3#hasFeature> <http://parts.igem.org/pSB1C5/annotation0> .
+<http://parts.igem.org/pSB1C5> <http://sbols.org/v3#hasFeature> <http://parts.igem.org/pSB1C5/annotation1> .
+<http://parts.igem.org/pSB1C5> <http://sbols.org/v3#hasFeature> <http://parts.igem.org/pSB1C5/annotation2> .
 <http://parts.igem.org/pSB1C5> <http://sbols.org/v3#hasNamespace> <http://parts.igem.org> .
-<http://parts.igem.org/pSB1C5> <http://sbols.org/v3#hasSequence> <http://parts.igem.org/pSB1C5_sequence> .
-<http://parts.igem.org/pSB1C5> <http://sbols.org/v3#name> "pSB1C5" .
+<http://parts.igem.org/pSB1C5> <http://sbols.org/v3#hasSequence> <http://parts.igem.org/pSB1C5_seq> .
 <http://parts.igem.org/pSB1C5> <http://sbols.org/v3#role> <https://identifiers.org/SO:0000155> .
+<http://parts.igem.org/pSB1C5> <http://sbols.org/v3#type> <http://identifiers.org/so/SO:0000988> .
 <http://parts.igem.org/pSB1C5> <http://sbols.org/v3#type> <https://identifiers.org/SBO:0000251> .
+<http://parts.igem.org/pSB1C5> <http://sboltools.org/backport#sbol2type> <http://sbols.org/v2#ComponentDefinition> .
+<http://parts.igem.org/pSB1C5> <http://www.ncbi.nlm.nih.gov/genbank#date> "21-JAN-2022" .
+<http://parts.igem.org/pSB1C5> <http://www.ncbi.nlm.nih.gov/genbank#keywords> "\"accession:pSB1C5\"" .
+<http://parts.igem.org/pSB1C5> <http://www.ncbi.nlm.nih.gov/genbank#locus> "pSB1C5" .
+<http://parts.igem.org/pSB1C5> <http://www.ncbi.nlm.nih.gov/genbank#molecule> "ds-DNA" .
 <http://parts.igem.org/pSB1C5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Component> .
 <http://parts.igem.org/pSB1C5_seq> <http://sbols.org/v3#displayId> "pSB1C5_seq" .
 <http://parts.igem.org/pSB1C5_seq> <http://sbols.org/v3#elements> "tccggcaaaaaagggcaaggtgtcaccaccctgccctttttctttaaaaccgaaaagattacttcgcgttatgcaggcttcctcgctcactgactcgctgcgctcggtcgttcggctgcggcgagcggtatcagctcactcaaaggcggtaatacggttatccacagaatcaggggataacgcaggaaagaacatgtgagcaaaaggccagcaaaaggccaggaaccgtaaaaaggccgcgttgctggcgtttttccacaggctccgcccccctgacgagcatcacaaaaatcgacgctcaagtcagaggtggcgaaacccgacaggactataaagataccaggcgtttccccctggaagctccctcgtgcgctctcctgttccgaccctgccgcttaccggatacctgtccgcctttctcccttcgggaagcgtggcgctttctcatagctcacgctgtaggtatctcagttcggtgtaggtcgttcgctccaagctgggctgtgtgcacgaaccccccgttcagcccgaccgctgcgccttatccggtaactatcgtcttgagtccaacccggtaagacacgacttatcgccactggcagcagccactggtaacaggattagcagagcgaggtatgtaggcggtgctacagagttcttgaagtggtggcctaactacggctacactagaagaacagtatttggtatctgcgctctgctgaagccagttaccttcggaaaaagagttggtagctcttgatccggcaaacaaaccaccgctggtagcggtggtttttttgtttgcaagcagcagattacgcgcagaaaaaaaggatctcaagaagatcctttgatcttttctacggggtctgacgctcagtggaacgaaaactcacgttaagggattttggtcatgagattatcaaaaaggatcttcacctagatccttttaaattaaaaatgaagttttaaatcaatctaaagtatatatgagtaaacttggtctgacagctcgaggcttggattctcaccaataaaaaacgcccggcggcaaccgagcgttctgaacaaatccagatggagttctgaggtcattactggatctatcaacaggagtccaagcgagctcgatatcaaattacgccccgccctgccactcatcgcagtactgttgtaattcattaagcattctgccgacatggaagccatcacaaacggcatgatgaacctgaatcgccagcggcatcagcaccttgtcgccttgcgtataatatttgcccatggtgaaaacgggggcgaagaagttgtccatattggccacgtttaaatcaaaactggtgaaactcacccagggattggctgagacgaaaaacatattctcaataaaccctttagggaaataggccaggttttcaccgtaacacgccacatcttgcgaatatatgtgtagaaactgccggaaatcgtcgtggtattcactccagagcgatgaaaacgtttcagtttgctcatggaaaacggtgtaacaagggtgaacactatcccatatcaccagctcaccgtctttcattgccatacgaaattccggatgagcattcatcaggcgggcaagaatgtgaataaaggccggataaaacttgtgcttatttttctttacggtctttaaaaaggccgtaatatccagctgaacggtctggttataggtacattgagcaactgactgaaatgcctcaaaatgttctttacgatgccattgggatatatcaacggtggtatatccagtgatttttttctccattttagcttccttagctcctgaaaatctcgataactcaaaaaatacgcccggtagtgatcttatttcattatggtgaaagttggaacctcttacgtgcccgatcaactcgagtgccacctgacgtctaagaaaccattattatcatgacattaacctataaaaataggcgtatcacgaggcagaatttcagataaaaaaaatccttagctttcgctaaggatgatttctg" .

--- a/distribution.gb
+++ b/distribution.gb
@@ -1337,8 +1337,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       392..449
+                     /label="his operon terminator"
+     misc_feature    644..1232
+                     /label="pMB1 replication origin"
+     misc_feature    complement(1530..2189)
+                     /label="chloramphenicol resistance marker"
      misc_feature    392..2418
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    381..391
@@ -1401,8 +1406,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       449..506
+                     /label="his operon terminator"
+     misc_feature    701..1289
+                     /label="pMB1 replication origin"
+     misc_feature    complement(1587..2246)
+                     /label="chloramphenicol resistance marker"
      misc_feature    449..2475
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    438..448
@@ -1645,8 +1655,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       4787..4844
+                     /label="his operon terminator"
+     misc_feature    5039..5627
+                     /label="pMB1 replication origin"
+     misc_feature    complement(5925..6584)
+                     /label="chloramphenicol resistance marker"
      misc_feature    4787..6813
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    4776..4786
@@ -1804,8 +1819,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       4838..4895
+                     /label="his operon terminator"
+     misc_feature    5090..5678
+                     /label="pMB1 replication origin"
+     misc_feature    complement(5976..6635)
+                     /label="chloramphenicol resistance marker"
      misc_feature    4838..6864
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    4827..4837
@@ -1972,8 +1992,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       5432..5489
+                     /label="his operon terminator"
+     misc_feature    5684..6272
+                     /label="pMB1 replication origin"
+     misc_feature    complement(6570..7229)
+                     /label="chloramphenicol resistance marker"
      misc_feature    5432..7458
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    5421..5431
@@ -2144,8 +2169,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       5582..5639
+                     /label="his operon terminator"
+     misc_feature    5834..6422
+                     /label="pMB1 replication origin"
+     misc_feature    complement(6720..7379)
+                     /label="chloramphenicol resistance marker"
      misc_feature    5582..7608
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    5571..5581
@@ -2334,8 +2364,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       4901..4958
+                     /label="his operon terminator"
+     misc_feature    5153..5741
+                     /label="pMB1 replication origin"
+     misc_feature    complement(6039..6698)
+                     /label="chloramphenicol resistance marker"
      misc_feature    4901..6927
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    4890..4900
@@ -2493,8 +2528,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       3935..3992
+                     /label="his operon terminator"
+     misc_feature    4187..4775
+                     /label="pMB1 replication origin"
+     misc_feature    complement(5073..5732)
+                     /label="chloramphenicol resistance marker"
      misc_feature    3935..5961
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    3924..3934
@@ -2624,8 +2664,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       4127..4184
+                     /label="his operon terminator"
+     misc_feature    4379..4967
+                     /label="pMB1 replication origin"
+     misc_feature    complement(5265..5924)
+                     /label="chloramphenicol resistance marker"
      misc_feature    4127..6153
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    4116..4126
@@ -2747,8 +2792,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       3707..3764
+                     /label="his operon terminator"
+     misc_feature    3959..4547
+                     /label="pMB1 replication origin"
+     misc_feature    complement(4845..5504)
+                     /label="chloramphenicol resistance marker"
      misc_feature    3707..5733
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    3696..3706
@@ -2868,8 +2918,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       3536..3593
+                     /label="his operon terminator"
+     misc_feature    3788..4376
+                     /label="pMB1 replication origin"
+     misc_feature    complement(4674..5333)
+                     /label="chloramphenicol resistance marker"
      misc_feature    3536..5562
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    3525..3535
@@ -2982,8 +3037,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       6374..6431
+                     /label="his operon terminator"
+     misc_feature    6626..7214
+                     /label="pMB1 replication origin"
+     misc_feature    complement(7512..8171)
+                     /label="chloramphenicol resistance marker"
      misc_feature    6374..8400
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    6363..6373
@@ -3157,8 +3217,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       3896..3953
+                     /label="his operon terminator"
+     misc_feature    4148..4736
+                     /label="pMB1 replication origin"
+     misc_feature    complement(5034..5693)
+                     /label="chloramphenicol resistance marker"
      misc_feature    3896..5922
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    3885..3895
@@ -3309,8 +3374,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       4127..4184
+                     /label="his operon terminator"
+     misc_feature    4379..4967
+                     /label="pMB1 replication origin"
+     misc_feature    complement(5265..5924)
+                     /label="chloramphenicol resistance marker"
      misc_feature    4127..6153
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    4116..4126
@@ -3437,8 +3507,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       3707..3764
+                     /label="his operon terminator"
+     misc_feature    3959..4547
+                     /label="pMB1 replication origin"
+     misc_feature    complement(4845..5504)
+                     /label="chloramphenicol resistance marker"
      misc_feature    3707..5733
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    3696..3706
@@ -3558,8 +3633,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       4127..4184
+                     /label="his operon terminator"
+     misc_feature    4379..4967
+                     /label="pMB1 replication origin"
+     misc_feature    complement(5265..5924)
+                     /label="chloramphenicol resistance marker"
      misc_feature    4127..6153
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    4116..4126
@@ -3686,8 +3766,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       3479..3536
+                     /label="his operon terminator"
+     misc_feature    3731..4319
+                     /label="pMB1 replication origin"
+     misc_feature    complement(4617..5276)
+                     /label="chloramphenicol resistance marker"
      misc_feature    3479..5505
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    3468..3478
@@ -3803,8 +3888,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       4127..4184
+                     /label="his operon terminator"
+     misc_feature    4379..4967
+                     /label="pMB1 replication origin"
+     misc_feature    complement(5265..5924)
+                     /label="chloramphenicol resistance marker"
      misc_feature    4127..6153
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    4116..4126
@@ -3931,8 +4021,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       3479..3536
+                     /label="his operon terminator"
+     misc_feature    3731..4319
+                     /label="pMB1 replication origin"
+     misc_feature    complement(4617..5276)
+                     /label="chloramphenicol resistance marker"
      misc_feature    3479..5505
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    3468..3478
@@ -4048,8 +4143,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       3284..3341
+                     /label="his operon terminator"
+     misc_feature    3536..4124
+                     /label="pMB1 replication origin"
+     misc_feature    complement(4422..5081)
+                     /label="chloramphenicol resistance marker"
      misc_feature    3284..5310
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    3273..3283
@@ -4160,8 +4260,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       4127..4184
+                     /label="his operon terminator"
+     misc_feature    4379..4967
+                     /label="pMB1 replication origin"
+     misc_feature    complement(5265..5924)
+                     /label="chloramphenicol resistance marker"
      misc_feature    4127..6153
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    4116..4126
@@ -10616,8 +10721,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       4127..4184
+                     /label="his operon terminator"
+     misc_feature    4379..4967
+                     /label="pMB1 replication origin"
+     misc_feature    complement(5265..5924)
+                     /label="chloramphenicol resistance marker"
      misc_feature    4127..6153
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    4116..4126
@@ -10744,8 +10854,13 @@ SOURCE      .
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
+     stem_loop       4127..4184
+                     /label="his operon terminator"
+     misc_feature    4379..4967
+                     /label="pMB1 replication origin"
+     misc_feature    complement(5265..5924)
+                     /label="chloramphenicol resistance marker"
      misc_feature    4127..6153
-                     /label="pSB1C5"
      misc_feature    1..8
                      /label="D1005"
      misc_feature    4116..4126

--- a/docs/contributing/documentation.rst
+++ b/docs/contributing/documentation.rst
@@ -5,9 +5,8 @@ What is the documentation for?
 ------------------------------
 
 The iGEM distribution documentation (docs) are a set of pages that serve to both explain things to new users/contributors to the distribution and also serve as a point of reference and 'single source of truth' for those who are already using/contributing.
-As such, we see *anything* that *anyone* doesn't understand about the distribution, or any standard procedure that isn't written down as a 'bug' in our documentation, so matter how small.
+As such, we see *anything* that *anyone* doesn't understand about the distribution, or any standard procedure that isn't written down as a 'bug' in our documentation, no matter how small.
 In fact, the smaller it is the more likely it is that other people have the same question!
-Obviously, this is a rather lofty goal, but
 We therefore welcome any contributions to the documentation, in the first instance by raising an issue with 'documentation' and 'enhancement'/'bug' tags but then, if possible, by working with us to improve the docs.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,8 @@ Welcome to iGEM-distribution's documentation!
 Getting started
 ---------------
 
-We know that this way of working may be unfamiliar to many of you, but we believe that it's the best way to make the development of the new distribution as open and collaborative as possible! Don't worry if you've never used github before:
+We know that this way of working may be unfamiliar to many of you, but we believe that it's the best way to make the development of the new distribution as open and collaborative as possible!
+Don't worry if you've never used github before:
 
 - :doc:`Guide to Github <getting_started/github>`
 


### PR DESCRIPTION
Make sure existing files are one-line-per-sentence and fix a couple of typos in the contributing to documentation page.