### PR TITLE
Docs quality-of-life improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv
 __pycache__
 *~
 .DS_Store
+/docs/_build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,3 +61,10 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+html_context = {
+  'display_github': True,
+  'github_user': 'iGEM-Engineering',
+  'github_repo': 'iGEM-distribution',
+  'github_version': 'develop/docs/',
+}


### PR DESCRIPTION
- Add docs/_build to .gitignore so that when people build the distribution locally this doesn't get added to their commits
- Edit the link at the top of docs pages so that it takes people to the relevant github page instead of just displaying the page source