### PR TITLE
Replace anti CRISP ducplicates

### DIFF
--- a/CRISPR-Cas/AcrIIA2_bacterial.gb
+++ b/CRISPR-Cas/AcrIIA2_bacterial.gb
@@ -1,8 +1,14 @@
-LOCUS       AcrIIA2_bacterial        372 bp ds-DNA     linear       02-FEB-2022
+LOCUS       AcrIIA2_bacterial        372 bp ds-DNA     linear       09-MAR-2022
 DEFINITION  .
 FEATURES             Location/Qualifiers
      CDS             1..372
                      /label="AcrIIA2_bacterial"
+                     /ApEinfo_revcolor=#c6c9d1
+                     /ApEinfo_fwdcolor=#c6c9d1
+     source          1..372
+                     /label="color: #ffffff"
+                     /ApEinfo_revcolor=#85dae9
+                     /ApEinfo_fwdcolor=#85dae9
      exon            1..372
                      /label="Translation 1-372"
 ORIGIN

--- a/CRISPR-Cas/AcrIIA4_bacterial.gb
+++ b/CRISPR-Cas/AcrIIA4_bacterial.gb
@@ -1,16 +1,20 @@
-LOCUS       AcrIIA4_bacterial        372 bp ds-DNA     linear       02-FEB-2022
+LOCUS       AcrIIA4_bacterial        264 bp ds-DNA     linear       09-MAR-2022
 DEFINITION  .
 FEATURES             Location/Qualifiers
-     CDS             1..372
-                     /label="AcrIIA2_bacterial"
-     exon            1..372
-                     /label="Translation 1-372"
+     CDS             1..264
+                     /label="AcrIIA4_bacterial"
+                     /ApEinfo_revcolor=#9eafd2
+                     /ApEinfo_fwdcolor=#9eafd2
+     source          1..264
+                     /label="color: #ffffff"
+                     /ApEinfo_revcolor=#c6c9d1
+                     /ApEinfo_fwdcolor=#c6c9d1
+     exon            1..264
+                     /label="Translation 1-264"
 ORIGIN
-        1 atgacattaa caagagcaca aaaaaagtat gcagaagcga tgcacgagtt tataaatatg
-       61 gtggatgact ttgaagagtc tacaccggat tttgcaaagg aagttctaca tgattctgac
-      121 tatgtagtta ttacaaaaaa tgaaaaatat gcagtagctc tttgctctct tagcactgat
-      181 gaatgtgaat atgatactaa cttatactta gatgaaaaat tggttgatta ctcaacagtt
-      241 gacgtaaacg gtgtgacata ctacatcaac attgttgaaa ctaacgatat cgatgattta
-      301 gaaatcgcta cggatgaaga tgagatgaaa agtggcaacc aagaaattat tttaaaaagt
-      361 gagttgaagt aa
+        1 atgaatatta atgacttaat tagagaaatc aaaaacaaag attacacagt gaaattgagt
+       61 ggtacggata gcaatagtat cacacagcta attattcgcg ttaataatga tggcaacgag
+      121 tatgtaattt ctgaaagtga aaatgaatca atcgttgaaa aattcatctc tgcattcaaa
+      181 aacggttgga atcaagaata cgaggatgaa gaagaatttt ataatgacat gcaaacaatc
+      241 accttaaaaa gtgagttgaa ctaa
 //

--- a/CRISPR-Cas/AcrIIA4_mammalian.gb
+++ b/CRISPR-Cas/AcrIIA4_mammalian.gb
@@ -1,16 +1,21 @@
-LOCUS       AcrIIA4_mammalian        372 bp ds-DNA     linear       02-FEB-2022
+LOCUS       AcrIIA4_mammalian        321 bp ds-DNA     linear       09-MAR-2022
 DEFINITION  .
 FEATURES             Location/Qualifiers
-     CDS             1..372
-                     /label="AcrIIA2_bacterial"
-     exon            1..372
-                     /label="Translation 1-372"
+     source          1..321
+                     /label="color: #ffffff"
+                     /ApEinfo_revcolor=#b4abac
+                     /ApEinfo_fwdcolor=#b4abac
+     CDS             1..321
+                     /label="AcrIIA4_mammalian"
+                     /ApEinfo_revcolor=#85dae9
+                     /ApEinfo_fwdcolor=#85dae9
+     exon            1..321
+                     /label="Translation 1-321"
 ORIGIN
-        1 atgacattaa caagagcaca aaaaaagtat gcagaagcga tgcacgagtt tataaatatg
-       61 gtggatgact ttgaagagtc tacaccggat tttgcaaagg aagttctaca tgattctgac
-      121 tatgtagtta ttacaaaaaa tgaaaaatat gcagtagctc tttgctctct tagcactgat
-      181 gaatgtgaat atgatactaa cttatactta gatgaaaaat tggttgatta ctcaacagtt
-      241 gacgtaaacg gtgtgacata ctacatcaac attgttgaaa ctaacgatat cgatgattta
-      301 gaaatcgcta cggatgaaga tgagatgaaa agtggcaacc aagaaattat tttaaaaagt
-      361 gagttgaagt aa
+        1 atgaacatta acgacctcat acgagagatt aagaacaaag attacaccgt caaactgtca
+       61 ggaactgata gtaactcaat cacccagctt attatcaggg taaacaatga tgggaatgaa
+      121 tatgtgatat ctgagagcga aaacgagtct atcgtcgaga aattcatttc cgcttttaag
+      181 aacgggtgga atcaggaata tgaggatgaa gaagaatttt acaatgacat gcagacgatc
+      241 acgttgaaaa gtgaactgaa ctaagaattc tgcagatatc cagcacagtg gcggccgctc
+      301 gagtctagag ggcccgttta a
 //


### PR DESCRIPTION
I replaced:

Anti_CRISPR_AcrIIA2_bacterial
Anti_CRISPR_AcrIIA4_bacterial
Anti_CRISPR_AcrIIA4_mammalian

With their correct sequence files. I had copy-pasted the same sequence in all three, hence the mistake. This should fix it!

Closes #234 