### PR TITLE
Update genbank tests

### DIFF
--- a/distribution.gb
+++ b/distribution.gb
@@ -14381,14 +14381,14 @@ FEATURES             Location/Qualifiers
                      /label="D1002"
      misc_feature    255..425
                      /label="D2002"
-     promoter        181..243
+     misc_feature    181..243
                      /label="pBetI"
      misc_feature    1..425
 ORIGIN
         1 aacgatgatg ctcactctcg ggtaccagca ttttcggagg ttctctaaca gtatggataa
        61 ccgtgttttc actgtgctgc ggttacccat cgcctgaaat ccagttggtg tcaagccatt
       121 ccctgtctag gacgccgcat gtagtaaaac atatacattg ctcgggttcg gtctcgggag
-      181 agcgcgggtg agagggattc gttaccaatt gacaattgat tggacgttca atataatgct
+      181 agcgcgggtg agagggattc gttaccaata gacaattgat tggacgttca atataatgct
       241 agctacttga gacctataaa cgccaggttg tatccgcatt tgatgctacc atggatgagt
       301 cagcgtcgag cacgcggcat ttattgcatg agtagggttg actaagaacc gttagatgcc
       361 tcgctgtact aataattgtc aacagatcgt caagattaga aaatagggtt tagtccggca

--- a/scripts/test/test_files/NCBI_GenBank_imports.gb
+++ b/scripts/test/test_files/NCBI_GenBank_imports.gb
@@ -8,7 +8,7 @@ DBLINK      BioProject: PRJNA266657
 KEYWORDS    WGS.
 SOURCE      Escherichia coli
   ORGANISM  Escherichia coli
-            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacterales;
+            Bacteria; Pseudomonadota; Gammaproteobacteria; Enterobacterales;
             Enterobacteriaceae; Escherichia.
 REFERENCE   1  (bases 1 to 3242)
   AUTHORS   Tyson,G.H., McDermott,P.F., Li,C., Chen,Y., Tadesse,D.A.,

--- a/scripts/test/test_files/distribution/distribution.nt
+++ b/scripts/test/test_files/distribution/distribution.nt
@@ -2183,7 +2183,7 @@
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#keywords> "WGS." .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#locus> "JWYZ01000115" .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#molecule> "DNA" .
-<https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#organism> "Escherichia coli Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacterales; Enterobacteriaceae; Escherichia." .
+<https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#organism> "Escherichia coli Bacteria; Pseudomonadota; Gammaproteobacteria; Enterobacterales; Enterobacteriaceae; Escherichia." .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#reference> <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115/reference0> .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#reference> <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115/reference1> .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#source> "Escherichia coli" .

--- a/scripts/test/test_files/imports/imports_test_ncbi.gb
+++ b/scripts/test/test_files/imports/imports_test_ncbi.gb
@@ -8,7 +8,7 @@ DBLINK      BioProject: PRJNA266657
 KEYWORDS    WGS.
 SOURCE      Escherichia coli
   ORGANISM  Escherichia coli
-            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacterales;
+            Bacteria; Pseudomonadota; Gammaproteobacteria; Enterobacterales;
             Enterobacteriaceae; Escherichia.
 REFERENCE   1  (bases 1 to 3242)
   AUTHORS   Tyson,G.H., McDermott,P.F., Li,C., Chen,Y., Tadesse,D.A.,

--- a/scripts/test/test_files/imports/package.nt
+++ b/scripts/test/test_files/imports/package.nt
@@ -914,7 +914,7 @@
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#keywords> "WGS." .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#locus> "JWYZ01000115" .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#molecule> "DNA" .
-<https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#organism> "Escherichia coli Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacterales; Enterobacteriaceae; Escherichia." .
+<https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#organism> "Escherichia coli Bacteria; Pseudomonadota; Gammaproteobacteria; Enterobacterales; Enterobacteriaceae; Escherichia." .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#reference> <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115/reference0> .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#reference> <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115/reference1> .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#source> "Escherichia coli" .

--- a/scripts/test/test_files/views/package-expanded.nt
+++ b/scripts/test/test_files/views/package-expanded.nt
@@ -2170,7 +2170,7 @@
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#keywords> "WGS." .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#locus> "JWYZ01000115" .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#molecule> "DNA" .
-<https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#organism> "Escherichia coli Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacterales; Enterobacteriaceae; Escherichia." .
+<https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#organism> "Escherichia coli Bacteria; Pseudomonadota; Gammaproteobacteria; Enterobacterales; Enterobacteriaceae; Escherichia." .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#reference> <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115/reference0> .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#reference> <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115/reference1> .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#source> "Escherichia coli" .

--- a/scripts/test/test_files/views/package.nt
+++ b/scripts/test/test_files/views/package.nt
@@ -1799,7 +1799,7 @@
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#keywords> "WGS." .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#locus> "JWYZ01000115" .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#molecule> "DNA" .
-<https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#organism> "Escherichia coli Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacterales; Enterobacteriaceae; Escherichia." .
+<https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#organism> "Escherichia coli Bacteria; Pseudomonadota; Gammaproteobacteria; Enterobacterales; Enterobacteriaceae; Escherichia." .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#reference> <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115/reference0> .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#reference> <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115/reference1> .
 <https://www.ncbi.nlm.nih.gov/nuccore/JWYZ01000115> <http://www.ncbi.nlm.nih.gov/genbank#source> "Escherichia coli" .


### PR DESCRIPTION
NCBI's taxonomy has changed Proteobacteria to Pseudomonadota, which affects all tests involving the GenBank import of an E. coli sequence